### PR TITLE
Add Drafts syntax definition for OmniFocus TaskPaper

### DIFF
--- a/OmniFocus TaskPaper.draftsSyntax
+++ b/OmniFocus TaskPaper.draftsSyntax
@@ -1,0 +1,76 @@
+{
+  "name": "OmniFocus TaskPaper",
+  "description": "Syntax highlighting for OmniFocus-extended TaskPaper template files, including projects, tasks, completed tasks, OmniFocus attributes, and URL deep links.",
+  "author": "Integral Productivity",
+  "version": "1.0",
+  "fileExtension": "taskpaper",
+  "elements": [
+    {
+      "type": "line",
+      "match": "^(\\t*)(-\\s)(.*)(@done)(.*)",
+      "exclusive": true,
+      "scopes": ["comment"],
+      "elements": []
+    },
+    {
+      "type": "line",
+      "match": "^(\\t*)(-\\s)(.*)",
+      "exclusive": true,
+      "scopes": ["markup.list"],
+      "elements": [
+        {
+          "type": "inline",
+          "match": "(@[a-zA-Z][a-zA-Z-]*)(\\()([^)]*)(\\))",
+          "exclusive": false,
+          "scopes": ["keyword.operator", "text", "string", "text"]
+        },
+        {
+          "type": "inline",
+          "match": "@[a-zA-Z][a-zA-Z-]*(?!\\()",
+          "exclusive": false,
+          "scopes": ["keyword.operator"]
+        },
+        {
+          "type": "inline",
+          "match": "[a-zA-Z][a-zA-Z0-9+.-]*://[^\\s<>\"'\\]]*",
+          "exclusive": false,
+          "scopes": ["markup.underline.link"]
+        },
+        {
+          "type": "inline",
+          "match": "«[^»]*»|\\[\\[[^\\]]+\\]\\]|\\[[^\\]]+\\]",
+          "exclusive": false,
+          "scopes": ["variable"]
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "match": "^(\\t*)(?!-\\s)([^\\t\\n].*?):[\\t ]*$",
+      "exclusive": true,
+      "scopes": ["markup.heading"],
+      "elements": []
+    },
+    {
+      "type": "line",
+      "match": "^[\\t ]*([a-zA-Z][a-zA-Z0-9+.-]*://[^\\s<>\"'\\]]*)",
+      "exclusive": false,
+      "scopes": ["text"],
+      "elements": [
+        {
+          "type": "inline",
+          "match": "[a-zA-Z][a-zA-Z0-9+.-]*://[^\\s<>\"'\\]]*",
+          "exclusive": false,
+          "scopes": ["markup.underline.link"]
+        }
+      ]
+    },
+    {
+      "type": "line",
+      "match": "^\\t+[^-\\t].*",
+      "exclusive": false,
+      "scopes": ["text"],
+      "elements": []
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -6,3 +6,18 @@ Find an explanation of how these are used together in the [OmniFocus Taskpaper R
 
 Users are strongly encouraged to load these templates into the [Drafts app](https://getdrafts.com) with Rosemary Orchard's [OF Taskpaper plugin](https://actions.getdrafts.com/g/1F6) by copying and pasting the text.
 
+## Syntax Highlighting
+
+A Drafts syntax definition (`OmniFocus TaskPaper.draftsSyntax`) is included in this repository to provide syntax highlighting when editing these templates in Drafts. To install it:
+
+1. In Drafts, open **Settings → Syntax → Import** and select the `OmniFocus TaskPaper.draftsSyntax` file, or
+2. Drag and drop the file onto the Drafts app window on macOS.
+
+The syntax highlights:
+- **Projects** — lines ending with `:`
+- **Tasks** — lines beginning with `- `
+- **Completed tasks** (`@done`) — rendered as dimmed comment text
+- **OmniFocus attributes** — `@attribute` names and their `(values)` in distinct colors
+- **URL deep links** — `omnifocus://`, `agenda://`, `dayone://`, `https://`, and other schemes
+- **Template placeholders** — `«guillemet»`, `[[wiki-link]]`, and `[bracket]` forms
+


### PR DESCRIPTION
## Summary

- Adds `OmniFocus TaskPaper.draftsSyntax`, a Drafts-native syntax definition file that provides syntax highlighting for OmniFocus-extended TaskPaper templates
- Updates `README.md` with import instructions and a description of what gets highlighted

## What gets highlighted

| Element | Scope | Example |
|---|---|---|
| Project lines | `markup.heading` | `Weekly Review:` |
| Task lines | `markup.list` | `- Clear inbox @parallel(false)` |
| Completed tasks (`@done`) | `comment` (dimmed) | `- Install Drafts @done` |
| Attribute names | `keyword.operator` | `@parallel`, `@context`, `@repeat-rule` |
| Attribute values | `string` | content inside `(...)` |
| URL deep links | `markup.underline.link` | `omnifocus:///inbox`, `agenda://today` |
| Template placeholders | `variable` | `«Boss Name»`, `[[draft_open_url]]`, `[insert link]` |

## Test plan

- [ ] Import `OmniFocus TaskPaper.draftsSyntax` into Drafts via Settings → Syntax → Import
- [ ] Open `projects/Weekly Review.taskpaper` — confirm project headers and tasks highlight correctly
- [ ] Open `projects/Closing the Day Routine.taskpaper` — confirm `agenda://today` URL note line highlights, and nested tasks at various indentation depths render correctly
- [ ] Open `actionGroups/Meta Work.taskpaper` — confirm bare `@flagged` (no parens) highlights as a keyword and `[[draft_open_url]]` placeholder highlights as a variable
- [ ] Open `projects/Managing My Boss.taskpaper` — confirm `«Boss Name»` placeholder highlights and project lines with trailing spaces after `:` render as headings

https://claude.ai/code/session_01AgymK8J3twBb6YgL9EErY4

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgymK8J3twBb6YgL9EErY4)_